### PR TITLE
OBJC-C compatibility

### DIFF
--- a/EFColorPicker/Classes/EFColorComponentView.swift
+++ b/EFColorPicker/Classes/EFColorComponentView.swift
@@ -131,7 +131,8 @@ public class EFColorComponentView: UIControl, UITextFieldDelegate {
     // Sets the array of CGColorRef objects defining the color of each gradient stop on a slider's track.
     // The location of each gradient stop is evaluated with formula: i * width_of_the_track / number_of_colors.
     // @param colors An array of CGColorRef objects.
-    func setColors(colors: [CGColor]) {
+    func setColors(colors: [UIColor]) {
+
         if colors.count <= 1 {
             fatalError("‘colors: [CGColor]’ at least need to have 2 elements")
         }

--- a/EFColorPicker/Classes/EFColorSelectionViewController.swift
+++ b/EFColorPicker/Classes/EFColorSelectionViewController.swift
@@ -28,7 +28,7 @@ import UIKit
 
 // The delegate of a EFColorSelectionViewController object must adopt the EFColorSelectionViewController protocol.
 // Methods of the protocol allow the delegate to handle color value changes.
-public protocol EFColorSelectionViewControllerDelegate: class {
+@objc public protocol EFColorSelectionViewControllerDelegate: NSObjectProtocol {
 
     // Tells the data source to return the color components.
     // @param colorViewCntroller The color view.

--- a/EFColorPicker/Classes/EFHSBView.swift
+++ b/EFColorPicker/Classes/EFHSBView.swift
@@ -224,7 +224,7 @@ public class EFHSBView: UIView, EFColorView, UITextFieldDelegate {
         let tmp: UIColor = UIColor(
             hue: colorComponents.hue, saturation: colorComponents.saturation , brightness: 1, alpha: 1
         )
-        brightnessView.setColors(colors: [UIColor.black.cgColor, tmp.cgColor])
+        brightnessView.setColors(colors: [UIColor.black, tmp])
     }
 
     @objc private func ef_colorDidChangeValue(sender: EFColorWheelView) {

--- a/EFColorPicker/Classes/EFRGBView.swift
+++ b/EFColorPicker/Classes/EFRGBView.swift
@@ -207,11 +207,13 @@ public class EFRGBView: UIView, EFColorView {
         let components = self.ef_colorComponentsWithRGB(rgb: colorComponents)
 
         for (idx, colorComponentView) in colorComponentViews.enumerated() {
-            colorComponentView.setColors(
-                colors: self.ef_colorsWithColorComponents(
-                    colorComponents: components, currentColorIndex: colorComponentView.tag
-                )
-            )
+            let cgColors: [CGColor] = self.ef_colorsWithColorComponents(colorComponents: components,
+                                                                             currentColorIndex: colorComponentView.tag)
+            let colors: [UIColor] = cgColors.map({ cgColor -> UIColor in
+                return UIColor(cgColor: cgColor)
+            })
+
+            colorComponentView.setColors(colors: colors)
             colorComponentView.value = components[idx] * colorComponentView.maximumValue
         }
     }

--- a/EFColorPicker/Classes/EFSliderView.swift
+++ b/EFColorPicker/Classes/EFSliderView.swift
@@ -68,7 +68,7 @@ public class EFSliderView: EFControl {
         thumbView.gestureRecognizer.addTarget(self, action: #selector(ef_didPanThumbView(gestureRecognizer:)))
         self.addSubview(thumbView)
 
-        let color = UIColor.blue.cgColor
+        let color = UIColor.blue
         self.setColors(colors: [color, color])
     }
 
@@ -103,11 +103,14 @@ public class EFSliderView: EFControl {
     // Sets the array of CGColorRef objects defining the color of each gradient stop on the track.
     // The location of each gradient stop is evaluated with formula: i * width_of_the_track / number_of_colors.
     // @param colors An array of CGColorRef objects.
-    func setColors(colors: [CGColor]) {
-        if colors.count <= 1 {
+    func setColors(colors: [UIColor]) {
+        let cgColors = colors.map { color -> CGColor in
+            return color.cgColor
+        }
+        if cgColors.count <= 1 {
             fatalError("‘colors: [CGColor]’ at least need to have 2 elements")
         }
-        trackLayer.colors = colors
+        trackLayer.colors = cgColors
         self.ef_updateLocations()
     }
 


### PR DESCRIPTION
To be compatible for OBJC we need to set the protocole as @objc and use
the keyword NSObjectProtocol instead of class. also OBJC does not like
arrays containing CGColor as they are not object in objc so we need to
use UIColor as mush as possible for every method call that are public
API calls.