### PR TITLE
Omit first argument label of delegate method

### DIFF
--- a/EFColorPicker/Classes/EFColorSelectionView.swift
+++ b/EFColorPicker/Classes/EFColorSelectionView.swift
@@ -113,9 +113,9 @@ public class EFColorSelectionView: UIView, EFColorView, EFColorViewDelegate {
     }
 
     // MARK:- FBColorViewDelegate methods
-    public func colorView(colorView: EFColorView, didChangeColor color: UIColor) {
+    public func colorView(_ colorView: EFColorView, didChangeColor color: UIColor) {
         self.color = color
-        self.delegate?.colorView(colorView: self, didChangeColor: self.color)
+        self.delegate?.colorView(self, didChangeColor: self.color)
     }
 
     // MARK:- Private

--- a/EFColorPicker/Classes/EFColorSelectionViewController.swift
+++ b/EFColorPicker/Classes/EFColorSelectionViewController.swift
@@ -33,7 +33,7 @@ import UIKit
     // Tells the data source to return the color components.
     // @param colorViewCntroller The color view.
     // @param color The new color value.
-    func colorViewController(colorViewCntroller: EFColorSelectionViewController, didChangeColor color: UIColor)
+    func colorViewController(_ colorViewCntroller: EFColorSelectionViewController, didChangeColor color: UIColor)
 }
 
 public class EFColorSelectionViewController: UIViewController, EFColorViewDelegate {
@@ -109,7 +109,7 @@ public class EFColorSelectionViewController: UIViewController, EFColorViewDelega
     }
 
     // MARK:- EFColorViewDelegate
-    public func colorView(colorView: EFColorView, didChangeColor color: UIColor) {
-        self.delegate?.colorViewController(colorViewCntroller: self, didChangeColor: color)
+    public func colorView(_ colorView: EFColorView, didChangeColor color: UIColor) {
+        self.delegate?.colorViewController(self, didChangeColor: color)
     }
 }

--- a/EFColorPicker/Classes/EFColorView.swift
+++ b/EFColorPicker/Classes/EFColorView.swift
@@ -33,7 +33,7 @@ public protocol EFColorViewDelegate: class {
     // Tells the data source to return the color components.
     // @param colorView The color view.
     // @param color The new color value.
-    func colorView(colorView: EFColorView, didChangeColor color: UIColor)
+    func colorView(_ colorView: EFColorView, didChangeColor color: UIColor)
 }
 
 /// The \c EFColorView protocol declares a view's interface for displaying and editing color value.

--- a/EFColorPicker/Classes/EFHSBView.swift
+++ b/EFColorPicker/Classes/EFHSBView.swift
@@ -229,14 +229,14 @@ public class EFHSBView: UIView, EFColorView, UITextFieldDelegate {
     @objc private func ef_colorDidChangeValue(sender: EFColorWheelView) {
         colorComponents.hue = sender.hue
         colorComponents.saturation = sender.saturation
-        self.delegate?.colorView(colorView: self, didChangeColor: self.color)
+        self.delegate?.colorView(self, didChangeColor: self.color)
         self.reloadData()
     }
 
     @objc private func ef_brightnessDidChangeValue(sender: EFColorComponentView) {
         colorComponents.brightness = sender.value
         self.colorWheel.brightness = sender.value
-        self.delegate?.colorView(colorView: self, didChangeColor: self.color)
+        self.delegate?.colorView(self, didChangeColor: self.color)
         self.reloadData()
     }
 }

--- a/EFColorPicker/Classes/EFRGBView.swift
+++ b/EFColorPicker/Classes/EFRGBView.swift
@@ -106,7 +106,7 @@ public class EFRGBView: UIView, EFColorView {
 
     @objc @IBAction private func ef_colorComponentDidChangeValue(_ sender: EFColorComponentView) {
         self.ef_setColorComponentValue(value: sender.value / sender.maximumValue, atIndex: UInt(sender.tag))
-        self.delegate?.colorView(colorView: self, didChangeColor: self.color)
+        self.delegate?.colorView(self, didChangeColor: self.color)
         self.reloadData()
     }
 

--- a/Example/EFColorPicker/ViewController.swift
+++ b/Example/EFColorPicker/ViewController.swift
@@ -112,7 +112,7 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
     }
 
     // MARK:- EFColorSelectionViewControllerDelegate
-    func colorViewController(colorViewCntroller: EFColorSelectionViewController, didChangeColor color: UIColor) {
+    func colorViewController(_ colorViewCntroller: EFColorSelectionViewController, didChangeColor color: UIColor) {
         self.view.backgroundColor = color
 
         // TODO: You can do something here when color changed.


### PR DESCRIPTION
I think to omit first argument label of delegate method is standard. For example, some delegate methods in `UIKit` omit first argument label.
https://developer.apple.com/documentation/uikit/uitextfielddelegate

Also, raywenderlich.com recommends the style.
https://github.com/raywenderlich/swift-style-guide#delegates