### PR TITLE
Feature/user interaction flag

### DIFF
--- a/EFColorPicker/Classes/EFColorComponentView.swift
+++ b/EFColorPicker/Classes/EFColorComponentView.swift
@@ -29,6 +29,7 @@ import UIKit
 // The view to edit a color component.
 public class EFColorComponentView: UIControl, UITextFieldDelegate {
 
+    // Indicates if the user touches the control at the moment
     var isCurrentlyTouched = false
     
     // Temporary disabled the color component editing via text field

--- a/EFColorPicker/Classes/EFColorComponentView.swift
+++ b/EFColorPicker/Classes/EFColorComponentView.swift
@@ -29,6 +29,8 @@ import UIKit
 // The view to edit a color component.
 public class EFColorComponentView: UIControl, UITextFieldDelegate {
 
+    var isCurrentlyTouched = false
+    
     // Temporary disabled the color component editing via text field
     public var colorTextFieldEnabled: Bool = false {
         didSet {
@@ -138,6 +140,13 @@ public class EFColorComponentView: UIControl, UITextFieldDelegate {
         }
 
         slider.setColors(colors: colors)
+    }
+    
+    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.isCurrentlyTouched = true
+    }
+    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.isCurrentlyTouched = false
     }
 
     // MARK:- Private methods

--- a/EFColorPicker/Classes/EFColorWheelView.swift
+++ b/EFColorPicker/Classes/EFColorWheelView.swift
@@ -29,6 +29,8 @@ import CoreGraphics
 
 // The color wheel view.
 public class EFColorWheelView: UIControl {
+    
+    var isCurrentlyTouched = false
 
     // The hue value.
     var hue: CGFloat = 0.0 {
@@ -94,6 +96,7 @@ public class EFColorWheelView: UIControl {
     }
 
     override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.isCurrentlyTouched = true
         if let position: CGPoint = touches.first?.location(in: self) {
             self.onTouchEventWithPosition(point: position)
         }
@@ -106,6 +109,7 @@ public class EFColorWheelView: UIControl {
     }
 
     override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.isCurrentlyTouched = false
         if let position: CGPoint = touches.first?.location(in: self) {
             self.onTouchEventWithPosition(point: position)
         }

--- a/EFColorPicker/Classes/EFHSBView.swift
+++ b/EFColorPicker/Classes/EFHSBView.swift
@@ -42,6 +42,20 @@ public class EFHSBView: UIView, EFColorView, UITextFieldDelegate {
 
     weak public var delegate: EFColorViewDelegate?
 
+    public var isCurrentlyTouched: Bool {
+        get {
+            if self.colorWheel.isCurrentlyTouched {
+                return true
+            }
+
+            if self.brightnessView.isCurrentlyTouched {
+                return true
+            }
+
+            return false
+        }
+    }
+
     public var color: UIColor {
         get {
             return UIColor(

--- a/EFColorPicker/Classes/EFHSBView.swift
+++ b/EFColorPicker/Classes/EFHSBView.swift
@@ -43,17 +43,15 @@ public class EFHSBView: UIView, EFColorView, UITextFieldDelegate {
     weak public var delegate: EFColorViewDelegate?
 
     public var isCurrentlyTouched: Bool {
-        get {
-            if self.colorWheel.isCurrentlyTouched {
-                return true
-            }
-
-            if self.brightnessView.isCurrentlyTouched {
-                return true
-            }
-
-            return false
+        if self.colorWheel.isCurrentlyTouched {
+            return true
         }
+
+        if self.brightnessView.isCurrentlyTouched {
+            return true
+        }
+
+        return false
     }
 
     public var color: UIColor {

--- a/EFColorPicker/Classes/EFRGBView.swift
+++ b/EFColorPicker/Classes/EFRGBView.swift
@@ -39,6 +39,10 @@ public class EFRGBView: UIView, EFColorView {
 
     weak public var delegate: EFColorViewDelegate?
 
+    public var isCurrentlyTouched: Bool {
+        return self.colorComponentViews.filter { $0.isCurrentlyTouched }.count > 0
+    }
+
     public var color: UIColor {
         get {
             return UIColor(


### PR DESCRIPTION
To be able to block picker updates (triggered by incoming events) while user is using the controls I introduced the indicator flag isCurrentlyTouched. You can now detect user interaction by reading this flag on EFHSBView and EFRGBView.