### PR TITLE
iOS 13 Dark Mode support

### DIFF
--- a/EFColorPicker/Classes/EFColorSelectionView.swift
+++ b/EFColorPicker/Classes/EFColorSelectionView.swift
@@ -126,7 +126,12 @@ public class EFColorSelectionView: UIView, EFColorView, EFColorViewDelegate {
         }
         self.accessibilityLabel = "color_selection_view"
 
-        self.backgroundColor = UIColor.white
+		if #available(iOS 13.0, *) {
+			self.backgroundColor = UIColor.systemBackground
+		} else {
+			self.backgroundColor = UIColor.white
+		}
+		
         self.addColorView(view: rgbColorView)
         self.addColorView(view: hsbColorView)
         self.setSelectedIndex(index: EFSelectedColorView.RGB, animated: false)


### PR DESCRIPTION
Simplest support for Dark Mode, make `EFColorSelectionView` background color to conform to `systemBackground`